### PR TITLE
Update de_tts.js: Don’t read out ref= tags for lower-tier highways, if a street name is available.

### DIFF
--- a/voice/de/de_tts.js
+++ b/voice/de/de_tts.js
@@ -409,12 +409,25 @@ function turn_street(streetName) {
 }
 
 function assemble_street_name(streetName) {
+	var toRef = streetName["toRef"]
+	/* Major roads highway=(motorway|primary|secondary|tertiary) in Germany 
+	 * have ref tags containing a type letter (A|B|L|K) and number, 
+	 * e.g. "ref=K 673" for a tertiary road. But only refs for motorways and highway=primary are
+	 * publicly visible on signposts, so reading the ref value of secondary or tertiary roads out loud
+	 * does not benefit the driver, as the information can not be cross-referenced with the
+	 * visible signs.
+	 * So only reference the roads by their ref attribute, if no actual street name is available,
+	 * which mainly happens in rural regions outside of towns.
+	 */
+	if ((toRef.startsWith("L") || toRef.startsWith("K")) && streetName["toStreetName"] != "") {
+		toRef = ""
+	}
 	if (streetName["toDest"] === "") {
-		return streetName["toRef"] + " " + streetName["toStreetName"];
-	} else if (streetName["toRef"] === "") {
+		return toRef + " " + streetName["toStreetName"];
+	} else if (toRef === "") {
 		return streetName["toStreetName"] + " " + dictionary["toward"] + " " + streetName["toDest"];
-	} else if (streetName["toRef"] != "") {
-		return streetName["toRef"] + " " + dictionary["toward"] + " " + streetName["toDest"];
+	} else if (toRef != "") {
+		return toRef + " " + dictionary["toward"] + " " + streetName["toDest"];
 	}
 }
 


### PR DESCRIPTION
Do not read out aloud ref=* values for highway=secondary and highway=tertiary, if a street name is available.

# Background and reasoning

Major roads highway=(motorway|primary|secondary|tertiary) in Germany 
have ref tags containing a type letter (A|B|L|K) respectively and number, 
e.g. "ref=K 673" for a tertiary road. But only refs for motorways and highway=primary are
publicly visible on signposts, with motorways being blue and primary roads being yellow:
![refs](https://user-images.githubusercontent.com/2143820/148101588-17dfac9a-2d10-4ef9-ad3f-62e37d234cb8.jpg)

The road numbers for secondary and tertiary highways are typically not printed on signs, especially inside cities.
It _may_ appear in rural areas if the street explicitly has no name, but I can’t remember having seen one ever.

So reading the ref value of secondary or tertiary roads out loud
does not benefit the driver, as the information can not be cross-referenced with the
visible signs. It increases the verbiage for no benefit.

The proposed change causes the TTS to omit reading out the ref tag for lower-grade roads, if a street name is available.

As a fallback, it still keeps the ref as the name, if no street name is available, because _any_ name is better than _none_.

As a test case, here is a [node of a crossing](https://www.openstreetmap.org/node/2297893627) that touches a primary highway, a tertiary highway with a name and a tertiary highway without name.

Turning east/west reads out “turn right on B1 Werler Straße”. (Reads out both ref and name)
Turning north reads out “turn left on Hemmerder Dorfstraße”. (Only reads out the name)
Turning south reads out “turn left on K35” (Uses the ref as a fallback, because the road has no name)